### PR TITLE
Posts

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Posts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,27 @@
+class PostsController < ApplicationController
+  skip_before_action :require_login, only: [:index, :new, :create]
+
+  def index
+    @posts = Post.all
+  end
+
+  def new
+    @post = current_user.posts.new
+  end
+
+  def create
+    @post = current_user.posts.build(post_params)
+    if @post.save!
+      redirect_to(user_posts_path(current_user), success: '投稿に成功しました')
+    else
+      flash.now[:alert] = '投稿に失敗しました'
+      render :new
+    end
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :body) #パラメーターのキー
+  end
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,4 @@
 class Post < ApplicationRecord
+  # アソシエーション
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  # アソシエーション
+  has_many :posts
+  
   authenticates_with_sorcery!
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,19 @@
+<h1>投稿一覧</h1>
+<table>
+  <thead>
+    <tr>
+      <td><%= link_to '新規投稿ページへ', new_user_post_path(current_user) %></td>
+      <td><%= link_to 'ユーザー一覧ページ', root_path %></td>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @posts.each do |post| %>
+      <tr>
+        <td><%= post.title %></td>
+        <td><%= post.body %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,13 @@
+<%= form_with(model: @post, local: true) do |form| %>
+  <div class="field">
+    <%= form.label :title %><br />
+    <%= form.text_field :title %>
+  </div>
+  <div class="field">
+    <%= form.label :body %><br />
+    <%= form.text_area :body %>
+  </div>
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,6 +15,7 @@
         <td><%= link_to 'Show', user %></td>
         <td><%= link_to 'Edit', edit_user_path(user) %></td>
         <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Post Index', user_posts_path(user) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   get 'user_sessions/destroy'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root :to => 'users#index'
-  resources :users
+  resources :users do
+    resources :posts
+  end
 
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :users do
     resources :posts
   end
+  resources :posts
 
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get posts_index_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get posts_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get posts_create_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
## 概要
- ユーザー一覧ページに投稿一覧ページに遷移するボタンを作成
- 投稿一覧ページにログインユーザーの新規投稿ページへ遷移するボタンを作成
- ユーザーに紐づく新規投稿機能を実装

## 使用gemや外部ツール
- sorcery

## 確認手順
- ユーザー一覧ページで、Post Indexボタンを押すと投稿一覧ページに遷移することを確認
- 投稿一覧ページにある新規投稿ページへというボタンを押すと新規投稿フォームへ遷移することを確認
- 投稿フォームに入力して作成ボタンを押すと、投稿することができ投稿一覧ページに遷移することを確認


## 参考資料
[Simple Password Authentication-Sorcery](https://github.com/Sorcery/sorcery/wiki/Simple-Password-Authentication)

[RESTful APIのURI設計(エンドポイント設計)](https://qiita.com/NagaokaKenichi/items/6298eb8960570c7ad2e9)
